### PR TITLE
Use correct date format that java.util.Date can read

### DIFF
--- a/acmeair-jmeter/src/main/java/com/acmeair/jmeter/functions/GenerateDateFunction.java
+++ b/acmeair-jmeter/src/main/java/com/acmeair/jmeter/functions/GenerateDateFunction.java
@@ -41,7 +41,7 @@ public class GenerateDateFunction extends AbstractFunction {
 	public String execute(SampleResult arg0, Sampler arg1)
 			throws InvalidVariableException {
 		SimpleDateFormat date_format = new SimpleDateFormat(
-				"EEE MMM dd 00:00:00 z yyyy");
+				"EEE, dd MMM yyyy 00:00:00 Z");
 		if (parameters.get(0).execute().equalsIgnoreCase("from")) {
 			Calendar aDay = Calendar.getInstance();
 			aDay.add(Calendar.DATE, new Random().nextInt(6));


### PR DESCRIPTION
java.util.Date is unable to read the current format being generated by the driver. This results in an obscure InvalidArgumentException when running the driver towards the Java acmeair implementation. This PR fixes this issue by generating dates that java.util.Date can parse. 